### PR TITLE
Coredump fix and adding sync interception functions

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,5 +1,6 @@
 Language: Cpp
 BasedOnStyle: Google
+AccessModifierOffset: 0
 AlignEscapedNewlinesLeft: false
 AlignOperands: false
 ColumnLimit: 100

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ option(CLR_BUILD_OCL "Build OCL" OFF)
 
 # Set default build type
 if(NOT CMAKE_BUILD_TYPE)
-    set(CMAKE_BUILD_TYPE "Debug")
+    set(CMAKE_BUILD_TYPE "Release")
 endif()
 
 #############

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ option(CLR_BUILD_OCL "Build OCL" OFF)
 
 # Set default build type
 if(NOT CMAKE_BUILD_TYPE)
-    set(CMAKE_BUILD_TYPE "Release")
+    set(CMAKE_BUILD_TYPE "Debug")
 endif()
 
 #############

--- a/hipamd/src/CMakeLists.txt
+++ b/hipamd/src/CMakeLists.txt
@@ -121,6 +121,7 @@ target_sources(amdhip64 PRIVATE
   hip_mempool.cpp
   hip_mempool_impl.cpp
   hip_module.cpp
+  hip_mrfs.cpp
   hip_peer.cpp
   hip_platform.cpp
   hip_profile.cpp

--- a/hipamd/src/hip_memory.cpp
+++ b/hipamd/src/hip_memory.cpp
@@ -26,6 +26,8 @@
 #include "platform/command.hpp"
 #include "platform/memory.hpp"
 #include "platform/external_memory.hpp"
+#include "hip_mrfs.hpp"
+
 namespace hip {
 
 amd::Monitor hipArraySetLock{"Guards global hipArray set"};
@@ -1564,7 +1566,9 @@ hipError_t hipMemcpyAsync_common(void* dst, const void* src, size_t sizeBytes,
   if (!hip::isValid(stream)) {
     return hipErrorContextIsDestroyed;
   }
-  return ihipMemcpy(dst, src, sizeBytes, kind, *hip_stream, true);
+  
+  return hipMemcpyAsync_mrfs(dst, src, sizeBytes, kind, *hip_stream);
+  // return ihipMemcpy(dst, src, sizeBytes, kind, *hip_stream, true);
 }
 
 hipError_t hipMemcpyAsync(void* dst, const void* src, size_t sizeBytes,

--- a/hipamd/src/hip_mrfs.cpp
+++ b/hipamd/src/hip_mrfs.cpp
@@ -1,121 +1,294 @@
 #include "hip_mrfs.hpp"
+#include <iostream>
+#include <hip/hip_runtime.h>
+#include <thread>
+#include <mutex>
+#include <vector>
+#include <map>
 #include <atomic>
+#include <condition_variable>
+#include "thread/thread.hpp"
+
+#define MRFS_DEBUG 0
+
+#if MRFS_DEBUG
+#define MRFS_LOG(tag, message) \
+  do { \
+    std::cerr << "[" << tag << "] " << message << std::endl; \
+  } while(0)
+#else
+#define MRFS_LOG(tag, message) do {} while(0)
+#endif
 
 namespace hip {
 
-std::thread* hipMemCpyThread = nullptr;
-std::mutex threadMutex;
-std::atomic<int> deviceSyncCount{0};
-std::atomic<int> streamSyncCount{0};
-std::atomic<bool> asyncMemcpyInProgress{false};
+// Forward declarations
+class Device;
+class Stream;
+extern hipError_t ihipDeviceSynchronize();
+extern hipError_t ihipStreamSynchronize(hipStream_t stream);
+extern hipError_t ihipMemcpy_validate(void* dst, const void* src, size_t sizeBytes,
+                                     hipMemcpyKind kind);
+// extern hipError_t ihipMemcpy(void* dst, const void* src, size_t sizeBytes,
+//                            hipMemcpyKind kind, hip::Stream& stream, bool isAsync);
+extern Device* getCurrentDevice();
+
+
+// Struct used to keep track of memory copy operations
+struct MemcpyTask {
+  void* dst;
+  const void* src;
+  size_t sizeBytes;
+  hipMemcpyKind kind;
+  hip::Stream* stream;
+  int deviceId;
+  std::atomic<bool> completed{false};
+};
+
+// Thread pool for paralell memory operations
+class MemcpyThreadPool {
+  private:
+      std::vector<std::thread> _workers;
+      std::vector<std::shared_ptr<MemcpyTask>> _tasks;
+      std::map<hip::Stream*, std::vector<std::shared_ptr<MemcpyTask>>> _streamTasks;
+      std::mutex _mutex;
+      std::condition_variable _condition;
+      std::atomic<bool> _stop{false};
+      std::atomic<int> _taskCount{0};
+    
+    void workerFunction() {
+      amd::Thread::init();
+      MRFS_LOG("WORKER", "Thread started");
+      
+      while (!_stop) {
+          std::shared_ptr<MemcpyTask> task;
+          
+          // Get a task
+          {
+              std::unique_lock<std::mutex> lock(_mutex);
+              _condition.wait(lock, [this]{ 
+                  return _stop || !_tasks.empty(); 
+              });
+              
+              if (_stop && _tasks.empty()) break;
+              
+              if (!_tasks.empty()) {
+                  task = _tasks.back();
+                  _tasks.pop_back();
+                  MRFS_LOG("WORKER", "Got task: " << task->sizeBytes << " bytes, src=" 
+                          << task->src << ", dst=" << task->dst);
+              }
+          }
+          
+          // Process the task
+          if (task) {
+              (void)hipSetDevice(task->deviceId);
+              MRFS_LOG("WORKER", "Executing task on device " << task->deviceId);
+              (void)ihipMemcpy(task->dst, task->src, task->sizeBytes, task->kind, *(task->stream), true);
+              MRFS_LOG("WORKER", "Task completed: " << task->sizeBytes << " bytes");
+              task->completed.store(true);
+          }
+      }
+      
+      MRFS_LOG("WORKER", "Thread exiting");
+  }
+
+  public:
+    // Initialize with specified number of threads
+    MemcpyThreadPool(int numThreads) {
+        MRFS_LOG("POOL", "Creating thread pool with " << numThreads << " threads");
+        for (int i = 0; i < numThreads; ++i) {
+            _workers.emplace_back(&MemcpyThreadPool::workerFunction, this);
+        }
+    }
+    
+    // Clean up
+    ~MemcpyThreadPool() {
+        MRFS_LOG("POOL", "Shutting down thread pool");
+        {
+            std::lock_guard<std::mutex> lock(_mutex);
+            _stop = true;
+        }
+        _condition.notify_all();
+        
+        for (auto& worker : _workers) {
+            if (worker.joinable()) worker.join();
+        }
+        MRFS_LOG("POOL", "Thread pool shutdown complete");
+    }
+    
+    // Add a new memory copy task
+    void addTask(void* dst, const void* src, size_t sizeBytes, 
+                hipMemcpyKind kind, hip::Stream* stream, int deviceId) {
+        auto task = std::make_shared<MemcpyTask>();
+        task->dst = dst;
+        task->src = src;
+        task->sizeBytes = sizeBytes;
+        task->kind = kind;
+        task->stream = stream;
+        task->deviceId = deviceId;
+        
+        int taskId = ++_taskCount;
+        MRFS_LOG("POOL", "Adding task " << taskId << ": " << sizeBytes << " bytes, device=" 
+                << deviceId << ", stream=" << stream);
+        
+        {
+            std::lock_guard<std::mutex> lock(_mutex);
+            _tasks.push_back(task);
+            _streamTasks[stream].push_back(task);
+        }
+        
+        _condition.notify_one();
+    }
+    
+    // Wait for stream tasks to complete
+    void waitForStream(hip::Stream* stream) {
+        MRFS_LOG("SYNC", "Waiting for stream " << stream);
+        std::vector<std::shared_ptr<MemcpyTask>> streamTasks;
+        
+        {
+            std::lock_guard<std::mutex> lock(_mutex);
+            if (_streamTasks.find(stream) != _streamTasks.end()) {
+                streamTasks = _streamTasks[stream];
+                MRFS_LOG("SYNC", "Found " << streamTasks.size() << " tasks for stream " << stream);
+            } else {
+                MRFS_LOG("SYNC", "No tasks found for stream " << stream);
+            }
+        }
+        
+        for (auto& task : streamTasks) {
+            while (!task->completed.load()) {
+                MRFS_LOG("SYNC", "Waiting for task to complete: " << task->sizeBytes << " bytes");
+                std::this_thread::yield();
+            }
+        }
+        
+        // Clean up completed tasks
+        {
+            std::lock_guard<std::mutex> lock(_mutex);
+            if (_streamTasks.find(stream) != _streamTasks.end()) {
+                MRFS_LOG("SYNC", "Clearing " << _streamTasks[stream].size() 
+                        << " completed tasks for stream " << stream);
+                _streamTasks[stream].clear();
+            }
+        }
+        
+        MRFS_LOG("SYNC", "Stream " << stream << " sync complete");
+    }
+    
+    // Wait for all tasks to complete
+    void waitForAll() {
+        MRFS_LOG("SYNC", "Waiting for all tasks to complete");
+        std::vector<std::shared_ptr<MemcpyTask>> allTasks;
+        
+        {
+            std::lock_guard<std::mutex> lock(_mutex);
+            // Get all tasks from all streams
+            for (auto& pair : _streamTasks) {
+                allTasks.insert(allTasks.end(), pair.second.begin(), pair.second.end());
+            }
+            // Also include any tasks not yet assigned to a worker
+            allTasks.insert(allTasks.end(), _tasks.begin(), _tasks.end());
+            
+            MRFS_LOG("SYNC", "Found " << allTasks.size() << " total tasks across all streams");
+        }
+        
+        // Wait for all tasks to complete
+        for (auto& task : allTasks) {
+            while (!task->completed.load()) {
+                MRFS_LOG("SYNC", "Waiting for task to complete: " << task->sizeBytes 
+                        << " bytes, stream=" << task->stream);
+                std::this_thread::yield();
+            }
+        }
+        
+        // Clean up
+        {
+            std::lock_guard<std::mutex> lock(_mutex);
+            MRFS_LOG("SYNC", "Clearing all completed tasks");
+            _streamTasks.clear();
+        }
+        
+        MRFS_LOG("SYNC", "All tasks complete");
+    }
+};
+
+// Singleton to manage the thread pool
+class ThreadManager {
+  private:
+      std::unique_ptr<MemcpyThreadPool> _pool;
+      
+      ThreadManager() {
+          int numDevices = 1;
+          (void)hipGetDeviceCount(&numDevices);
+          MRFS_LOG("MANAGER", "Initializing thread manager with " << numDevices << " devices");
+          _pool = std::make_unique<MemcpyThreadPool>(numDevices * 2);
+      }
+      
+  public:
+      static ThreadManager& instance() {
+          static ThreadManager manager;
+          return manager;
+      }
+      
+      MemcpyThreadPool* pool() { return _pool.get(); }
+  };
 
 
 hipError_t hipMemcpyAsync_mrfs(void* dst, const void* src, size_t sizeBytes, 
-                             hipMemcpyKind kind, hip::Stream& stream) {
-  hipError_t status;
-  
+    hipMemcpyKind kind, hip::Stream& stream) {
+  MRFS_LOG("HIPAPI", "hipMemcpyAsync_mrfs: " << sizeBytes << " bytes, src=" 
+          << src << ", dst=" << dst);
+
   if (sizeBytes == 0) {
+    MRFS_LOG("HIPAPI", "Empty copy, returning success");
     return hipSuccess;
   }
-  
-  status = ihipMemcpy_validate(dst, src, sizeBytes, kind);
+
+  hipError_t status = ihipMemcpy_validate(dst, src, sizeBytes, kind);
   if (status != hipSuccess) {
+    MRFS_LOG("HIPAPI", "Validation failed with error " << status);
     return status;
   }
-  
+
   if (src == dst && kind == hipMemcpyDefault) {
+    MRFS_LOG("HIPAPI", "Same src/dst with default kind, skipping");
     return hipSuccess;
   }
 
-  int deviceId = getCurrentDevice()->deviceId();
-  
-  auto memcpyWork = [deviceId, dst, src, sizeBytes, kind, &stream]() {
-
-    amd::Thread::init();
-    (void)hipSetDevice(deviceId);
-    
-    // fprintf(stderr, "[INTERCEPT] Starting async memcpy: %zu bytes, src=%p, dst=%p\n", 
-    //         sizeBytes, src, dst);
-    
-    asyncMemcpyInProgress.store(true);
-    
-    hipError_t result = ihipMemcpy(dst, src, sizeBytes, kind, stream, true);
-    
-    // fprintf(stderr, "[INTERCEPT] Completed async memcpy: %zu bytes, result=%d\n", 
-    //         sizeBytes, result);
-    
-    asyncMemcpyInProgress.store(false);
-  };
-
-  std::lock_guard<std::mutex> lock(threadMutex);
-  
-  // Clean up previous thread if it exists...
-  if (hipMemCpyThread && hipMemCpyThread->joinable()) {
-    // fprintf(stderr, "[INTERCEPT] Joining previous memcpy thread before starting new one\n");
-    hipMemCpyThread->join();
-    delete hipMemCpyThread;
-  }
-
-  // Create and start new thread
-  // fprintf(stderr, "[INTERCEPT] Starting new async memcpy thread\n");
-  hipMemCpyThread = new std::thread(memcpyWork);
+  // Add to thread pool
+  MRFS_LOG("HIPAPI", "Submitting to thread pool");
+  ThreadManager::instance().pool()->addTask(
+    dst, src, sizeBytes, kind, &stream, getCurrentDevice()->deviceId());
 
   return hipSuccess;
 }
 
-// Intercepted hipDeviceSynchronize
-hipError_t interceptedHipDeviceSynchronize() {
-  int count = ++deviceSyncCount;
-  
-  fprintf(stderr, "[INTERCEPT] hipDeviceSynchronize called (count: %d)\n", count);
-  
-  // Check to see if async copy in progress
-  if (asyncMemcpyInProgress.load()) {
-    fprintf(stderr, "[INTERCEPT] hipDeviceSynchronize called while async copy in progress!\n");
-  }
-  
-  std::lock_guard<std::mutex> lock(threadMutex);
-  
-  // Join any ongoing memory copy thread
-  if (hipMemCpyThread && hipMemCpyThread->joinable()) {
-    fprintf(stderr, "[INTERCEPT] Joining memcpy thread in hipDeviceSynchronize\n");
-    hipMemCpyThread->join();
-    delete hipMemCpyThread;
-    hipMemCpyThread = nullptr;
-  }
-  
-  fprintf(stderr, "[INTERCEPT] Calling original ihipDeviceSynchronize\n");
+// Device synchronization
+inline hipError_t interceptedHipDeviceSynchronize() {
+  MRFS_LOG("HIPAPI", "interceptedHipDeviceSynchronize called");
+  // Wait for all memory operations to complete
+  ThreadManager::instance().pool()->waitForAll();
+
+  MRFS_LOG("HIPAPI", "Calling original ihipDeviceSynchronize");
   hipError_t result = ihipDeviceSynchronize();
   
-  fprintf(stderr, "[INTERCEPT] hipDeviceSynchronize completed with status: %d\n", result);
-  
+  MRFS_LOG("HIPAPI", "ihipDeviceSynchronize returned " << result);
   return result;
 }
 
-// Intercepted hipStreamSynchronize
-hipError_t interceptedHipStreamSynchronize(hipStream_t stream) {
-  int count = ++streamSyncCount;
+// Stream synchronization
+inline hipError_t interceptedHipStreamSynchronize(hipStream_t streamHandle) {
+  MRFS_LOG("HIPAPI", "interceptedHipStreamSynchronize called for stream " << streamHandle);
   
-  fprintf(stderr, "[INTERCEPT] hipStreamSynchronize called (count: %d, stream: %p)\n", 
-          count, stream);
+  hip::Stream* stream = reinterpret_cast<hip::Stream*>(streamHandle);
+  // Wait for stream operations to complete
+  ThreadManager::instance().pool()->waitForStream(stream);
+
+  MRFS_LOG("HIPAPI", "Calling original ihipStreamSynchronize");
+  hipError_t result = ihipStreamSynchronize(streamHandle);
   
-  std::lock_guard<std::mutex> lock(threadMutex);
-  
-  // Join any ongoing memory copy thread if it's for this stream
-  // TODO: add checking if the thread is working on this specific stream
-  if (hipMemCpyThread && hipMemCpyThread->joinable()) {
-    fprintf(stderr, "[INTERCEPT] Joining memcpy thread in hipStreamSynchronize\n");
-    hipMemCpyThread->join();
-    delete hipMemCpyThread;
-    hipMemCpyThread = nullptr;
-  }
-  
-  // Call original implementation
-  fprintf(stderr, "[INTERCEPT] Calling original ihipStreamSynchronize\n");
-  hipError_t result = ihipStreamSynchronize(stream);
-  
-  fprintf(stderr, "[INTERCEPT] hipStreamSynchronize completed with status: %d\n", result);
-  
+  MRFS_LOG("HIPAPI", "ihipStreamSynchronize returned " << result);
   return result;
 }
 

--- a/hipamd/src/hip_mrfs.cpp
+++ b/hipamd/src/hip_mrfs.cpp
@@ -1,0 +1,122 @@
+#include "hip_mrfs.hpp"
+#include <atomic>
+
+namespace hip {
+
+std::thread* hipMemCpyThread = nullptr;
+std::mutex threadMutex;
+std::atomic<int> deviceSyncCount{0};
+std::atomic<int> streamSyncCount{0};
+std::atomic<bool> asyncMemcpyInProgress{false};
+
+
+hipError_t hipMemcpyAsync_mrfs(void* dst, const void* src, size_t sizeBytes, 
+                             hipMemcpyKind kind, hip::Stream& stream) {
+  hipError_t status;
+  
+  if (sizeBytes == 0) {
+    return hipSuccess;
+  }
+  
+  status = ihipMemcpy_validate(dst, src, sizeBytes, kind);
+  if (status != hipSuccess) {
+    return status;
+  }
+  
+  if (src == dst && kind == hipMemcpyDefault) {
+    return hipSuccess;
+  }
+
+  int deviceId = getCurrentDevice()->deviceId();
+  
+  auto memcpyWork = [deviceId, dst, src, sizeBytes, kind, &stream]() {
+
+    amd::Thread::init();
+    (void)hipSetDevice(deviceId);
+    
+    // fprintf(stderr, "[INTERCEPT] Starting async memcpy: %zu bytes, src=%p, dst=%p\n", 
+    //         sizeBytes, src, dst);
+    
+    asyncMemcpyInProgress.store(true);
+    
+    hipError_t result = ihipMemcpy(dst, src, sizeBytes, kind, stream, true);
+    
+    // fprintf(stderr, "[INTERCEPT] Completed async memcpy: %zu bytes, result=%d\n", 
+    //         sizeBytes, result);
+    
+    asyncMemcpyInProgress.store(false);
+  };
+
+  std::lock_guard<std::mutex> lock(threadMutex);
+  
+  // Clean up previous thread if it exists...
+  if (hipMemCpyThread && hipMemCpyThread->joinable()) {
+    // fprintf(stderr, "[INTERCEPT] Joining previous memcpy thread before starting new one\n");
+    hipMemCpyThread->join();
+    delete hipMemCpyThread;
+  }
+
+  // Create and start new thread
+  // fprintf(stderr, "[INTERCEPT] Starting new async memcpy thread\n");
+  hipMemCpyThread = new std::thread(memcpyWork);
+
+  return hipSuccess;
+}
+
+// Intercepted hipDeviceSynchronize
+hipError_t interceptedHipDeviceSynchronize() {
+  int count = ++deviceSyncCount;
+  
+  fprintf(stderr, "[INTERCEPT] hipDeviceSynchronize called (count: %d)\n", count);
+  
+  // Check to see if async copy in progress
+  if (asyncMemcpyInProgress.load()) {
+    fprintf(stderr, "[INTERCEPT] hipDeviceSynchronize called while async copy in progress!\n");
+  }
+  
+  std::lock_guard<std::mutex> lock(threadMutex);
+  
+  // Join any ongoing memory copy thread
+  if (hipMemCpyThread && hipMemCpyThread->joinable()) {
+    fprintf(stderr, "[INTERCEPT] Joining memcpy thread in hipDeviceSynchronize\n");
+    hipMemCpyThread->join();
+    delete hipMemCpyThread;
+    hipMemCpyThread = nullptr;
+  }
+  
+  fprintf(stderr, "[INTERCEPT] Calling original ihipDeviceSynchronize\n");
+  hipError_t result = ihipDeviceSynchronize();
+  
+  fprintf(stderr, "[INTERCEPT] hipDeviceSynchronize completed with status: %d\n", result);
+  
+  return result;
+}
+
+// Intercepted hipStreamSynchronize
+hipError_t interceptedHipStreamSynchronize(hipStream_t stream) {
+  int count = ++streamSyncCount;
+  
+  fprintf(stderr, "[INTERCEPT] hipStreamSynchronize called (count: %d, stream: %p)\n", 
+          count, stream);
+  
+  std::lock_guard<std::mutex> lock(threadMutex);
+  
+  // Join any ongoing memory copy thread if it's for this stream
+  // TODO: add checking if the thread is working on this specific stream
+  if (hipMemCpyThread && hipMemCpyThread->joinable()) {
+    fprintf(stderr, "[INTERCEPT] Joining memcpy thread in hipStreamSynchronize\n");
+    hipMemCpyThread->join();
+    delete hipMemCpyThread;
+    hipMemCpyThread = nullptr;
+  }
+  
+  // Call original implementation
+  fprintf(stderr, "[INTERCEPT] Calling original ihipStreamSynchronize\n");
+  hipError_t result = ihipStreamSynchronize(stream);
+  
+  fprintf(stderr, "[INTERCEPT] hipStreamSynchronize completed with status: %d\n", result);
+  
+  return result;
+}
+
+} // namespace hip

--- a/hipamd/src/hip_mrfs.cpp
+++ b/hipamd/src/hip_mrfs.cpp
@@ -12,12 +12,14 @@
 #define MRFS_DEBUG 0
 
 #if MRFS_DEBUG
-#define MRFS_LOG(tag, message) \
-  do { \
-    std::cerr << "[" << tag << "] " << message << std::endl; \
-  } while(0)
+#define MRFS_LOG(tag, message)                                                                     \
+  do {                                                                                             \
+    std::cerr << "[" << tag << "] " << message << std::endl;                                       \
+  } while (0)
 #else
-#define MRFS_LOG(tag, message) do {} while(0)
+#define MRFS_LOG(tag, message)                                                                     \
+  do {                                                                                             \
+  } while (0)
 #endif
 
 namespace hip {
@@ -28,11 +30,10 @@ class Stream;
 extern hipError_t ihipDeviceSynchronize();
 extern hipError_t ihipStreamSynchronize(hipStream_t stream);
 extern hipError_t ihipMemcpy_validate(void* dst, const void* src, size_t sizeBytes,
-                                     hipMemcpyKind kind);
+                                      hipMemcpyKind kind);
 // extern hipError_t ihipMemcpy(void* dst, const void* src, size_t sizeBytes,
 //                            hipMemcpyKind kind, hip::Stream& stream, bool isAsync);
 extern Device* getCurrentDevice();
-
 
 // Struct used to keep track of memory copy operations
 struct MemcpyTask {
@@ -48,197 +49,199 @@ struct MemcpyTask {
 // Thread pool for paralell memory operations
 class MemcpyThreadPool {
   private:
-      std::vector<std::thread> _workers;
-      std::vector<std::shared_ptr<MemcpyTask>> _tasks;
-      std::map<hip::Stream*, std::vector<std::shared_ptr<MemcpyTask>>> _streamTasks;
-      std::mutex _mutex;
-      std::condition_variable _condition;
-      std::atomic<bool> _stop{false};
-      std::atomic<int> _taskCount{0};
-    
-    void workerFunction() {
-      amd::Thread::init();
-      MRFS_LOG("WORKER", "Thread started");
-      
-      while (!_stop) {
-          std::shared_ptr<MemcpyTask> task;
-          
-          // Get a task
-          {
-              std::unique_lock<std::mutex> lock(_mutex);
-              _condition.wait(lock, [this]{ 
-                  return _stop || !_tasks.empty(); 
-              });
-              
-              if (_stop && _tasks.empty()) break;
-              
-              if (!_tasks.empty()) {
-                  task = _tasks.back();
-                  _tasks.pop_back();
-                  MRFS_LOG("WORKER", "Got task: " << task->sizeBytes << " bytes, src=" 
-                          << task->src << ", dst=" << task->dst);
-              }
-          }
-          
-          // Process the task
-          if (task) {
-              (void)hipSetDevice(task->deviceId);
-              MRFS_LOG("WORKER", "Executing task on device " << task->deviceId);
-              (void)ihipMemcpy(task->dst, task->src, task->sizeBytes, task->kind, *(task->stream), true);
-              MRFS_LOG("WORKER", "Task completed: " << task->sizeBytes << " bytes");
-              task->completed.store(true);
-          }
+  std::vector<std::thread> _workers;
+  std::vector<std::shared_ptr<MemcpyTask>> _tasks;
+  std::map<hip::Stream*, std::vector<std::shared_ptr<MemcpyTask>>> _streamTasks;
+  std::mutex _mutex;
+  std::condition_variable _condition;
+  std::atomic<bool> _stop{false};
+  std::atomic<int> _taskCount{0};
+
+  void workerFunction() {
+    amd::Thread::init();
+    MRFS_LOG("WORKER", "Thread started");
+
+    while (!_stop) {
+      std::shared_ptr<MemcpyTask> task;
+
+      // Get a task
+      {
+        std::unique_lock<std::mutex> lock(_mutex);
+        _condition.wait(lock, [this] { return _stop || !_tasks.empty(); });
+
+        if (_stop && _tasks.empty()) break;
+
+        if (!_tasks.empty()) {
+          task = _tasks.back();
+          _tasks.pop_back();
+          MRFS_LOG("WORKER",
+                   "Got task: " << task->sizeBytes << " bytes, src=" << task->src
+                                << ", dst=" << task->dst);
+        }
       }
-      
-      MRFS_LOG("WORKER", "Thread exiting");
+
+      // Process the task
+      if (task) {
+        (void)hipSetDevice(task->deviceId);
+        MRFS_LOG("WORKER", "Executing task on device " << task->deviceId);
+        (void)ihipMemcpy(task->dst, task->src, task->sizeBytes, task->kind, *(task->stream), true);
+        MRFS_LOG("WORKER", "Task completed: " << task->sizeBytes << " bytes");
+        task->completed.store(true);
+      }
+    }
+
+    MRFS_LOG("WORKER", "Thread exiting");
   }
 
   public:
-    // Initialize with specified number of threads
-    MemcpyThreadPool(int numThreads) {
-        MRFS_LOG("POOL", "Creating thread pool with " << numThreads << " threads");
-        for (int i = 0; i < numThreads; ++i) {
-            _workers.emplace_back(&MemcpyThreadPool::workerFunction, this);
-        }
+  // Initialize with specified number of threads
+  MemcpyThreadPool(int numThreads) {
+    MRFS_LOG("POOL", "Creating thread pool with " << numThreads << " threads");
+    for (int i = 0; i < numThreads; ++i) {
+      _workers.emplace_back(&MemcpyThreadPool::workerFunction, this);
     }
-    
-    // Clean up
-    ~MemcpyThreadPool() {
-        MRFS_LOG("POOL", "Shutting down thread pool");
-        {
-            std::lock_guard<std::mutex> lock(_mutex);
-            _stop = true;
-        }
-        _condition.notify_all();
-        
-        for (auto& worker : _workers) {
-            if (worker.joinable()) worker.join();
-        }
-        MRFS_LOG("POOL", "Thread pool shutdown complete");
+  }
+
+  // Clean up
+  ~MemcpyThreadPool() {
+    MRFS_LOG("POOL", "Shutting down thread pool");
+    {
+      std::lock_guard<std::mutex> lock(_mutex);
+      _stop = true;
     }
-    
-    // Add a new memory copy task
-    void addTask(void* dst, const void* src, size_t sizeBytes, 
-                hipMemcpyKind kind, hip::Stream* stream, int deviceId) {
-        auto task = std::make_shared<MemcpyTask>();
-        task->dst = dst;
-        task->src = src;
-        task->sizeBytes = sizeBytes;
-        task->kind = kind;
-        task->stream = stream;
-        task->deviceId = deviceId;
-        
-        int taskId = ++_taskCount;
-        MRFS_LOG("POOL", "Adding task " << taskId << ": " << sizeBytes << " bytes, device=" 
-                << deviceId << ", stream=" << stream);
-        
-        {
-            std::lock_guard<std::mutex> lock(_mutex);
-            _tasks.push_back(task);
-            _streamTasks[stream].push_back(task);
-        }
-        
-        _condition.notify_one();
+    _condition.notify_all();
+
+    for (auto& worker : _workers) {
+      if (worker.joinable()) worker.join();
     }
-    
-    // Wait for stream tasks to complete
-    void waitForStream(hip::Stream* stream) {
-        MRFS_LOG("SYNC", "Waiting for stream " << stream);
-        std::vector<std::shared_ptr<MemcpyTask>> streamTasks;
-        
-        {
-            std::lock_guard<std::mutex> lock(_mutex);
-            if (_streamTasks.find(stream) != _streamTasks.end()) {
-                streamTasks = _streamTasks[stream];
-                MRFS_LOG("SYNC", "Found " << streamTasks.size() << " tasks for stream " << stream);
-            } else {
-                MRFS_LOG("SYNC", "No tasks found for stream " << stream);
-            }
-        }
-        
-        for (auto& task : streamTasks) {
-            while (!task->completed.load()) {
-                MRFS_LOG("SYNC", "Waiting for task to complete: " << task->sizeBytes << " bytes");
-                std::this_thread::yield();
-            }
-        }
-        
-        // Clean up completed tasks
-        {
-            std::lock_guard<std::mutex> lock(_mutex);
-            if (_streamTasks.find(stream) != _streamTasks.end()) {
-                MRFS_LOG("SYNC", "Clearing " << _streamTasks[stream].size() 
-                        << " completed tasks for stream " << stream);
-                _streamTasks[stream].clear();
-            }
-        }
-        
-        MRFS_LOG("SYNC", "Stream " << stream << " sync complete");
+    MRFS_LOG("POOL", "Thread pool shutdown complete");
+  }
+
+  // Add a new memory copy task
+  void addTask(void* dst, const void* src, size_t sizeBytes, hipMemcpyKind kind,
+               hip::Stream* stream, int deviceId) {
+    auto task = std::make_shared<MemcpyTask>();
+    task->dst = dst;
+    task->src = src;
+    task->sizeBytes = sizeBytes;
+    task->kind = kind;
+    task->stream = stream;
+    task->deviceId = deviceId;
+
+    int taskId = ++_taskCount;
+    MRFS_LOG("POOL",
+             "Adding task " << taskId << ": " << sizeBytes << " bytes, device=" << deviceId
+                            << ", stream=" << stream);
+
+    {
+      std::lock_guard<std::mutex> lock(_mutex);
+      _tasks.push_back(task);
+      _streamTasks[stream].push_back(task);
     }
-    
+
+    _condition.notify_one();
+  }
+
+  // Wait for stream tasks to complete
+  void waitForStream(hip::Stream* stream) {
+    MRFS_LOG("SYNC", "Waiting for stream " << stream);
+    std::vector<std::shared_ptr<MemcpyTask>> streamTasks;
+
+    {
+      std::lock_guard<std::mutex> lock(_mutex);
+      if (_streamTasks.find(stream) != _streamTasks.end()) {
+        streamTasks = _streamTasks[stream];
+        MRFS_LOG("SYNC", "Found " << streamTasks.size() << " tasks for stream " << stream);
+      } else {
+        MRFS_LOG("SYNC", "No tasks found for stream " << stream);
+      }
+    }
+
+    for (auto& task : streamTasks) {
+      while (!task->completed.load()) {
+        MRFS_LOG("SYNC", "Waiting for task to complete: " << task->sizeBytes << " bytes");
+        std::this_thread::yield();
+      }
+    }
+
+    // Clean up completed tasks
+    {
+      std::lock_guard<std::mutex> lock(_mutex);
+      if (_streamTasks.find(stream) != _streamTasks.end()) {
+        MRFS_LOG(
+            "SYNC",
+            "Clearing " << _streamTasks[stream].size() << " completed tasks for stream " << stream);
+        _streamTasks[stream].clear();
+      }
+    }
+
+    MRFS_LOG("SYNC", "Stream " << stream << " sync complete");
+  }
+
+  // Wait for all tasks to complete
+  void waitForAll() {
+    MRFS_LOG("SYNC", "Waiting for all tasks to complete");
+    std::vector<std::shared_ptr<MemcpyTask>> allTasks;
+
+    {
+      std::lock_guard<std::mutex> lock(_mutex);
+      // Get all tasks from all streams
+      for (auto& pair : _streamTasks) {
+        allTasks.insert(allTasks.end(), pair.second.begin(), pair.second.end());
+      }
+      // Also include any tasks not yet assigned to a worker
+      allTasks.insert(allTasks.end(), _tasks.begin(), _tasks.end());
+
+      MRFS_LOG("SYNC", "Found " << allTasks.size() << " total tasks across all streams");
+    }
+
     // Wait for all tasks to complete
-    void waitForAll() {
-        MRFS_LOG("SYNC", "Waiting for all tasks to complete");
-        std::vector<std::shared_ptr<MemcpyTask>> allTasks;
-        
-        {
-            std::lock_guard<std::mutex> lock(_mutex);
-            // Get all tasks from all streams
-            for (auto& pair : _streamTasks) {
-                allTasks.insert(allTasks.end(), pair.second.begin(), pair.second.end());
-            }
-            // Also include any tasks not yet assigned to a worker
-            allTasks.insert(allTasks.end(), _tasks.begin(), _tasks.end());
-            
-            MRFS_LOG("SYNC", "Found " << allTasks.size() << " total tasks across all streams");
-        }
-        
-        // Wait for all tasks to complete
-        for (auto& task : allTasks) {
-            while (!task->completed.load()) {
-                MRFS_LOG("SYNC", "Waiting for task to complete: " << task->sizeBytes 
-                        << " bytes, stream=" << task->stream);
-                std::this_thread::yield();
-            }
-        }
-        
-        // Clean up
-        {
-            std::lock_guard<std::mutex> lock(_mutex);
-            MRFS_LOG("SYNC", "Clearing all completed tasks");
-            _streamTasks.clear();
-        }
-        
-        MRFS_LOG("SYNC", "All tasks complete");
+    for (auto& task : allTasks) {
+      while (!task->completed.load()) {
+        MRFS_LOG("SYNC",
+                 "Waiting for task to complete: " << task->sizeBytes
+                                                  << " bytes, stream=" << task->stream);
+        std::this_thread::yield();
+      }
     }
+
+    // Clean up
+    {
+      std::lock_guard<std::mutex> lock(_mutex);
+      MRFS_LOG("SYNC", "Clearing all completed tasks");
+      _streamTasks.clear();
+    }
+
+    MRFS_LOG("SYNC", "All tasks complete");
+  }
 };
 
 // Singleton to manage the thread pool
 class ThreadManager {
   private:
-      std::unique_ptr<MemcpyThreadPool> _pool;
-      
-      ThreadManager() {
-          int numDevices = 1;
-          (void)hipGetDeviceCount(&numDevices);
-          MRFS_LOG("MANAGER", "Initializing thread manager with " << numDevices << " devices");
-          _pool = std::make_unique<MemcpyThreadPool>(numDevices * 2);
-      }
-      
+  std::unique_ptr<MemcpyThreadPool> _pool;
+
+  ThreadManager() {
+    int numDevices = 1;
+    (void)hipGetDeviceCount(&numDevices);
+    MRFS_LOG("MANAGER", "Initializing thread manager with " << numDevices << " devices");
+    _pool = std::make_unique<MemcpyThreadPool>(numDevices * 2);
+  }
+
   public:
-      static ThreadManager& instance() {
-          static ThreadManager manager;
-          return manager;
-      }
-      
-      MemcpyThreadPool* pool() { return _pool.get(); }
-  };
+  static ThreadManager& instance() {
+    static ThreadManager manager;
+    return manager;
+  }
+
+  MemcpyThreadPool* pool() { return _pool.get(); }
+};
 
 
-hipError_t hipMemcpyAsync_mrfs(void* dst, const void* src, size_t sizeBytes, 
-    hipMemcpyKind kind, hip::Stream& stream) {
-  MRFS_LOG("HIPAPI", "hipMemcpyAsync_mrfs: " << sizeBytes << " bytes, src=" 
-          << src << ", dst=" << dst);
+hipError_t hipMemcpyAsync_mrfs(void* dst, const void* src, size_t sizeBytes, hipMemcpyKind kind,
+                               hip::Stream& stream) {
+  MRFS_LOG("HIPAPI",
+           "hipMemcpyAsync_mrfs: " << sizeBytes << " bytes, src=" << src << ", dst=" << dst);
 
   if (sizeBytes == 0) {
     MRFS_LOG("HIPAPI", "Empty copy, returning success");
@@ -258,8 +261,8 @@ hipError_t hipMemcpyAsync_mrfs(void* dst, const void* src, size_t sizeBytes,
 
   // Add to thread pool
   MRFS_LOG("HIPAPI", "Submitting to thread pool");
-  ThreadManager::instance().pool()->addTask(
-    dst, src, sizeBytes, kind, &stream, getCurrentDevice()->deviceId());
+  ThreadManager::instance().pool()->addTask(dst, src, sizeBytes, kind, &stream,
+                                            getCurrentDevice()->deviceId());
 
   return hipSuccess;
 }
@@ -272,7 +275,7 @@ inline hipError_t interceptedHipDeviceSynchronize() {
 
   MRFS_LOG("HIPAPI", "Calling original ihipDeviceSynchronize");
   hipError_t result = ihipDeviceSynchronize();
-  
+
   MRFS_LOG("HIPAPI", "ihipDeviceSynchronize returned " << result);
   return result;
 }
@@ -280,16 +283,16 @@ inline hipError_t interceptedHipDeviceSynchronize() {
 // Stream synchronization
 inline hipError_t interceptedHipStreamSynchronize(hipStream_t streamHandle) {
   MRFS_LOG("HIPAPI", "interceptedHipStreamSynchronize called for stream " << streamHandle);
-  
+
   hip::Stream* stream = reinterpret_cast<hip::Stream*>(streamHandle);
   // Wait for stream operations to complete
   ThreadManager::instance().pool()->waitForStream(stream);
 
   MRFS_LOG("HIPAPI", "Calling original ihipStreamSynchronize");
   hipError_t result = ihipStreamSynchronize(streamHandle);
-  
+
   MRFS_LOG("HIPAPI", "ihipStreamSynchronize returned " << result);
   return result;
 }
 
-} // namespace hip
+}  // namespace hip

--- a/hipamd/src/hip_mrfs.hpp
+++ b/hipamd/src/hip_mrfs.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <hip/hip_runtime.h>
+#include <thread>
+#include <mutex>
+#include <iostream>
+#include "thread/thread.hpp"
+#include "hip_internal.hpp"
+#include "hip_mrfs.hpp"
+
+namespace hip {
+
+extern std::thread* hipMemCpyThread;
+extern std::mutex threadMutex;
+
+// Forward declarations of the original sync functions we need to call
+extern hipError_t ihipDeviceSynchronize();
+extern hipError_t ihipStreamSynchronize(hipStream_t stream);
+extern hipError_t ihipMemcpy_validate(void* dst, const void* src, size_t sizeBytes,
+                                     hipMemcpyKind kind);
+// extern hipError_t ihipMemcpy(void* dst, const void* src, size_t sizeBytes,
+//                            hipMemcpyKind kind, hip::Stream& stream, bool isAsync);
+
+// Our custom async implementation
+hipError_t hipMemcpyAsync_mrfs(void* dst, const void* src, size_t sizeBytes, 
+                             hipMemcpyKind kind, hip::Stream& stream);
+
+// Our intercepted synchronization functions
+hipError_t interceptedHipDeviceSynchronize();
+hipError_t interceptedHipStreamSynchronize(hipStream_t stream);
+
+} // namespace hip


### PR DESCRIPTION
Adding interceptedHipDeviceSynchronize() and interceptedHipStreamSynchronize() to be used later to intercept DeviceSync and StreamSync calls.

Also added join() call in hipMemcpyAsync_mrfs() to avoid coredump crash.